### PR TITLE
uvpp::Async in thread-safe manner

### DIFF
--- a/async.hpp
+++ b/async.hpp
@@ -3,7 +3,6 @@
 #include "handle.hpp"
 #include "error.hpp"
 #include "loop.hpp"
-#include <chrono>
 
 namespace uvpp
 {

--- a/async.hpp
+++ b/async.hpp
@@ -4,34 +4,37 @@
 #include "error.hpp"
 #include "loop.hpp"
 #include <chrono>
-#include <iostream>
 
 namespace uvpp
 {
     class Async : public handle<uv_async_t>
     {
     public:
-        Async(loop &l): handle<uv_async_t>(), loop_(l.get())
+        Async(loop &l, std::function<void()> callback): handle<uv_async_t>(), loop_(l.get())
         {
-            
+            init(callback);
         }
         
-        Async(): handle<uv_async_t>(), loop_(uv_default_loop())
+        Async(std::function<void()> callback): handle<uv_async_t>(), loop_(uv_default_loop())
         {
-            
+            init(callback);
         }
         
-        error send(std::function<void()> callback) {
-            callbacks::store(get()->data, internal::uv_cid_async, callback);
-
-            uv_async_init(loop_, get(), [](uv_async_t* handle){
-                callbacks::invoke<decltype(callback)>(handle->data, internal::uv_cid_async);
-            });
-            
+        error send() {
             return error(uv_async_send(get()));
         }
 
     private:
+        
+        error init(std::function<void()> callback)
+        {
+            callbacks::store(get()->data, internal::uv_cid_async, callback);
+
+            return error(uv_async_init(loop_, get(), [](uv_async_t* handle){
+                callbacks::invoke<decltype(callback)>(handle->data, internal::uv_cid_async);
+            }));
+        }
+        
         uv_loop_t *loop_;   
 
     };

--- a/callback.hpp
+++ b/callback.hpp
@@ -24,6 +24,7 @@ namespace uvpp
             uv_cid_poll,
             uv_cid_signal,
             uv_cid_async,
+            uv_cid_idle,
             uv_cid_fs_open,
             uv_cid_fs_read,
             uv_cid_fs_write,

--- a/handle.hpp
+++ b/handle.hpp
@@ -2,7 +2,6 @@
 
 #include "callback.hpp"
 #include "error.hpp"
-#include <iostream>
 
 namespace uvpp
 {
@@ -50,7 +49,7 @@ namespace uvpp
                     delete reinterpret_cast<uv_poll_t*>(*h);
                     break;
 
-                case UV_ASYNC: 
+                case UV_ASYNC:
                     delete reinterpret_cast<uv_async_t*>(*h);
                     break;
 

--- a/handle.hpp
+++ b/handle.hpp
@@ -52,11 +52,15 @@ namespace uvpp
                 case UV_ASYNC:
                     delete reinterpret_cast<uv_async_t*>(*h);
                     break;
+                
+                case UV_IDLE:
+                    delete reinterpret_cast<uv_idle_t*>(*h);
+                    break;
 
                 case UV_FS_EVENT: 
                     delete reinterpret_cast<uv_fs_event_t*>(*h);
-                    break;                    
-
+                    break;
+                
                 default:
                     assert(0);
                     throw std::runtime_error("free_handle can't handle this type");
@@ -126,9 +130,9 @@ namespace uvpp
             return reinterpret_cast<const T*>(m_uv_handle);
         }
 
-        bool is_active()
+        bool is_active() const
         {
-            return uv_is_active(get()) != 0;
+            return uv_is_active(reinterpret_cast<const uv_handle_t*>(m_uv_handle)) != 0;
         }
 
         void close(std::function<void()> callback = []{})

--- a/handle.hpp
+++ b/handle.hpp
@@ -137,6 +137,11 @@ namespace uvpp
 
         void close(std::function<void()> callback = []{})
         {
+            if (uv_is_closing(get<uv_handle_t>()))
+            {
+                return; // prevent assertion on double close
+            }
+            
             callbacks::store(get()->data, internal::uv_cid_close, callback);
             m_will_close = true;
             uv_close(get<uv_handle_t>(),

--- a/idle.hpp
+++ b/idle.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "request.hpp"
+#include "error.hpp"
+#include "loop.hpp"
+
+namespace uvpp
+{
+    class Idle : public handle<uv_idle_t>
+    {
+    public:        
+        Idle(std::function<void()> callback):
+            handle<uv_idle_t>(), loop_(uv_default_loop())
+        {
+            init(loop_, callback);
+        }
+            
+        Idle(loop& l, std::function<void()> callback):
+            handle<uv_idle_t>(), loop_(l.get())
+        {
+            init(loop_, callback);
+        }
+        
+        error start()
+        {
+            return error(uv_idle_start(get(), [](uv_idle_t* req)
+            {
+                callbacks::invoke<std::function<void()>>(req->data, internal::uv_cid_idle);
+            }));
+            
+        }
+        
+        error stop()
+        {
+            return error(uv_idle_stop(get()));
+        }
+
+    private:
+        
+        void init(uv_loop_t *loop, std::function<void()> callback)
+        {
+            callbacks::store(get()->data, internal::uv_cid_idle, callback);
+            uv_idle_init(loop, get());
+        }
+        
+    	uv_loop_t *loop_;  	       	
+    };
+}
+
+
+

--- a/loop.hpp
+++ b/loop.hpp
@@ -70,8 +70,7 @@ namespace uvpp
          */
         bool run_once()
         {
-            int err = uv_run(m_uv_loop, UV_RUN_ONCE);
-            return err == 0;
+            return uv_run(m_uv_loop, UV_RUN_ONCE) == 0;
         }
 
         /**

--- a/loop.hpp
+++ b/loop.hpp
@@ -18,10 +18,13 @@ namespace uvpp
          */
         loop(bool use_default=false)
             : default_loop(use_default)
-            , m_uv_loop(use_default ? uv_default_loop() : new uv_loop_t)
-            //, m_uv_loop(use_default ? uv_default_loop() : uv_loop_new())
+            , m_uv_loop(use_default ? uv_default_loop() : new uv_loop_t
+                    ,   [this](uv_loop_t *loop)
+                        {
+                            destroy(loop);
+                        })
         {
-            if (!default_loop && uv_loop_init(m_uv_loop))
+            if (!default_loop && uv_loop_init(m_uv_loop.get()))
             {
                 throw std::runtime_error("uv_loop_init error");
             }            
@@ -34,54 +37,38 @@ namespace uvpp
         {
             if (m_uv_loop)
             {
-                uv_loop_close(m_uv_loop);
-                delete m_uv_loop;
+                uv_loop_close(m_uv_loop.get());
             }
-            // if (m_uv_loop)
-            //     uv_loop_delete(m_uv_loop);
-            
-            /*
-            if(m_uv_loop && !default_loop)
-            {
-                uv_loop_delete(m_uv_loop);
-//                uv_loop_close(m_uv_loop);
-//                delete m_uv_loop;
-                m_uv_loop = nullptr;
-            }*/
         }
 
         loop(const loop&) = delete;
         loop& operator=(const loop&) = delete;
-        loop(loop&& other):
-            m_uv_loop(other.m_uv_loop)
+        loop(loop&& other)
+            : m_uv_loop(std::forward<decltype(other.m_uv_loop)>(other.m_uv_loop))          
         {
-            if (this != &other)
-                other.m_uv_loop = nullptr;
+
         }
 
         loop& operator=(loop&& other)
         {
             if (this != &other)
             {
-                m_uv_loop = other.m_uv_loop;
-                other.m_uv_loop = nullptr;
+                m_uv_loop = std::forward<decltype(other.m_uv_loop)>(other.m_uv_loop);
             }
             return *this;
         }
 
-
-
         /**
          *  Returns internal handle for libuv functions.
          */
-        uv_loop_t* get() { return m_uv_loop; }
+        uv_loop_t* get() { return m_uv_loop.get(); }
 
         /**
          *  Starts the loop.
          */
         bool run()
         {
-            return uv_run(m_uv_loop, UV_RUN_DEFAULT) == 0;
+            return uv_run(m_uv_loop.get(), UV_RUN_DEFAULT) == 0;
         }
 
         /**
@@ -89,30 +76,40 @@ namespace uvpp
          */
         bool run_once()
         {
-            return uv_run(m_uv_loop, UV_RUN_ONCE) == 0;
+            return uv_run(m_uv_loop.get(), UV_RUN_ONCE) == 0;
         }
 
         /**
          *  ...
          *  Internally, this function just calls uv_update_time() function.
          */
-        void update_time() { uv_update_time(m_uv_loop); }
+        void update_time() { uv_update_time(m_uv_loop.get()); }
 
         /**
          *  ...
          *  Internally, this function just calls uv_now() function.
          */
-        int64_t now() { return uv_now(m_uv_loop); }
+        int64_t now() { return uv_now(m_uv_loop.get()); }
         
         /**
          * Stops the loop        
          */
-        void stop() { uv_stop(m_uv_loop); }
+        void stop() { uv_stop(m_uv_loop.get()); }
         
     private:
+        
+        // Custom deleter
+        typedef std::function<void(uv_loop_t*)> Deleter;
+        void destroy(uv_loop_t *loop) const
+        {
+            if (!default_loop)
+            {
+                delete loop;
+            }
+        }
+        
         bool default_loop;
-        uv_loop_t* m_uv_loop;
-        // std::unique_ptr<uv_loop_t> m_uv_loop; 
+        std::unique_ptr<uv_loop_t, Deleter> m_uv_loop; 
      };
 
     /**

--- a/loop.hpp
+++ b/loop.hpp
@@ -35,8 +35,9 @@ namespace uvpp
          */
         ~loop()
         {
-            if (m_uv_loop)
+            if (m_uv_loop.get())
             {
+                // no matter default loop or not: http://nikhilm.github.io/uvbook/basics.html#event-loops
                 uv_loop_close(m_uv_loop.get());
             }
         }

--- a/loop.hpp
+++ b/loop.hpp
@@ -70,7 +70,8 @@ namespace uvpp
          */
         bool run_once()
         {
-            return uv_run(m_uv_loop, UV_RUN_ONCE) == 0;
+            int err = uv_run(m_uv_loop, UV_RUN_ONCE);
+            return err == 0;
         }
 
         /**

--- a/loop.hpp
+++ b/loop.hpp
@@ -84,7 +84,12 @@ namespace uvpp
          *  Internally, this function just calls uv_now() function.
          */
         int64_t now() { return uv_now(m_uv_loop); }
-
+        
+        /**
+         * Stops the loop        
+         */
+        void stop() { uv_stop(m_uv_loop); }
+        
     private:
         uv_loop_t* m_uv_loop;
         bool default_loop;

--- a/signal.hpp
+++ b/signal.hpp
@@ -24,7 +24,7 @@ namespace uvpp
 
         error start(std::function<void(int signum)> callback) {        	
 			callbacks::store(get()->data, internal::uv_cid_signal, callback);
-        	return error(uv_timer_start(get(),
+        	return error(uv_signal_start(get(),
         		[](uv_poll_t* handle, int status, int events){
         			callbacks::invoke<decltype(callback)>(handle->data, internal::uv_cid_signal, status, events);
         		}
@@ -32,7 +32,7 @@ namespace uvpp
         }
 
         error stop() {
-			return error(uv_timer_stop(get()));            	
+			return error(uv_sigbal_stop(get()));            	
         }
     };
 }    

--- a/signal.hpp
+++ b/signal.hpp
@@ -16,19 +16,19 @@ namespace uvpp
         }
 
         Signal(loop& l):
-            handle<uv_poll_t>()
+            handle<uv_signal_t>()
         {
             uv_signal_init(l.get(), get());
         }
              
 
-        error start(std::function<void(int signum)> callback) {        	
+        error start(int signum, std::function<void(int signum)> callback) {        	
 			callbacks::store(get()->data, internal::uv_cid_signal, callback);
         	return error(uv_signal_start(get(),
-        		[](uv_poll_t* handle, int status, int events){
-        			callbacks::invoke<decltype(callback)>(handle->data, internal::uv_cid_signal, status, events);
-        		}
-        		));        	
+        		[](uv_signal_t* handle, int signum){
+        			callbacks::invoke<decltype(callback)>(handle->data, internal::uv_cid_signal, signum);
+        		},
+                        signum));        	
         }
 
         error stop() {

--- a/signal.hpp
+++ b/signal.hpp
@@ -35,4 +35,4 @@ namespace uvpp
 			return error(uv_signal_stop(get()));            	
         }
     };
-}    
+}

--- a/signal.hpp
+++ b/signal.hpp
@@ -32,7 +32,7 @@ namespace uvpp
         }
 
         error stop() {
-			return error(uv_sigbal_stop(get()));            	
+			return error(uv_signal_stop(get()));            	
         }
     };
 }    

--- a/stream.hpp
+++ b/stream.hpp
@@ -4,6 +4,8 @@
 #include "error.hpp"
 #include <algorithm>
 
+#include <iostream>
+
 namespace uvpp
 {
     template<typename HANDLE_T>
@@ -57,7 +59,7 @@ namespace uvpp
                     {
                         callbacks::invoke<decltype(callback)>(s->data, uvpp::internal::uv_cid_read_start, buf->base, nread);
                     }
-                    delete buf->base;
+                    delete [] buf->base;
                 }) == 0;
         }
 

--- a/timer.hpp
+++ b/timer.hpp
@@ -3,7 +3,6 @@
 #include "handle.hpp"
 #include "error.hpp"
 #include <chrono>
-#include <iostream>
 
 namespace uvpp
 {
@@ -34,8 +33,7 @@ namespace uvpp
         }
 
         error start(std::function<void()> callback, const std::chrono::duration<uint64_t, std::milli> &timeout) {
-        	std::cout << "timeout: " << timeout.count() << std::endl;
-			callbacks::store(get()->data, internal::uv_cid_timer, callback);
+        		callbacks::store(get()->data, internal::uv_cid_timer, callback);
         	return error(uv_timer_start(get(),
         		[](uv_timer_t* handle){
         			callbacks::invoke<decltype(callback)>(handle->data, internal::uv_cid_timer);


### PR DESCRIPTION
It was a design flaw in my last pull request. I misunderstood ideology of libuv.
I red documentation more carefully and found that the only one thread-safe call in libuv is uv_async().
(For inter-thread communication I mean:-) 
My previous pull request breaks this design, because it encourages to initialize async_t in separate of event loop thread. Furthermore, commit was due to the fact that I wanted to write code in thread-unsafe manner.
I want to repair upstream:-) You may apply this request, or just roll-back the old one.
